### PR TITLE
fix: dto resolution issues on accounts

### DIFF
--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -34,9 +34,11 @@ import { AccountTypes } from 'src/common/enums/accountTypes';
 import { Permissions } from 'src/common/enums/permissions';
 import { AccountsService } from './accounts.service';
 import { CreateAdministratorDto } from './dto/administrators/create-administrator.dto';
+import { CreateCompanyDto } from './dto/companies/create-company.dto';
 import { CreateAccountDto } from './dto/create-account.dto';
 import { ListAccountsResponseDto } from './dto/list-accounts.response.dto';
 import { CreateManagedDto } from './dto/managed/create-managed.dto';
+import { CreateStudentDto } from './dto/students/create-student.dto';
 import { UpdateAccountDto } from './dto/update-account.dto';
 import { Account } from './entities/account.entity';
 import { Administrator } from './entities/admin.entity';
@@ -158,8 +160,23 @@ export class AccountsController {
     @AuthAccount()
     auth: Account,
   ) {
-    const { admin, company, managed, student } = info;
-    const defined = [admin, company, managed, student].filter((dto) => !!dto);
+    const relatedDtos = {
+      admin: CreateAdministratorDto,
+      company: CreateCompanyDto,
+      managed: CreateManagedDto,
+      student: CreateStudentDto,
+    };
+
+    const defined = Object.keys(relatedDtos)
+      .map((key: keyof typeof relatedDtos) => {
+        if (!info[key]) {
+          return undefined;
+        }
+
+        return Object.assign(new relatedDtos[key](), info[key]);
+      })
+      .filter((dto) => !!dto);
+
     if (defined.length !== 1) {
       throw new BadRequestException(
         'The account must define one of the admin, company, student or managed information.',

--- a/src/accounts/companies.controller.ts
+++ b/src/accounts/companies.controller.ts
@@ -125,7 +125,10 @@ export class CompaniesController {
     @Body()
     dto: UpdateCompanyDto,
   ) {
-    const updated = await this.accountsService.update(id, dto);
+    const updated = await this.accountsService.update(
+      id,
+      Object.assign(new UpdateCompanyDto(), dto),
+    );
     if (updated instanceof HttpException) {
       throw updated;
     }

--- a/src/accounts/managed.controller.ts
+++ b/src/accounts/managed.controller.ts
@@ -240,7 +240,10 @@ export class ManagedController {
       }
     }
 
-    const updated = this.accountsService.update(found.id, dto);
+    const updated = await this.accountsService.update(
+      found.id,
+      Object.assign(new UpdateManagedDto(), dto),
+    );
     if (updated instanceof HttpException) {
       throw updated;
     }

--- a/src/accounts/students.controller.ts
+++ b/src/accounts/students.controller.ts
@@ -124,7 +124,10 @@ export class StudentsController {
     @Body()
     dto: UpdateStudentDto,
   ) {
-    const updated = await this.accountsService.update(id, dto);
+    const updated = await this.accountsService.update(
+      id,
+      Object.assign(new UpdateStudentDto(), dto),
+    );
     if (updated instanceof HttpException) {
       throw updated;
     }


### PR DESCRIPTION
## Contexte
Le service "accounts" vérifie si les paramètres données sont bien du type de l'instance demandé.
Hors le décorateur "@Body()" renvoie un object et non l'instaciation de la classe dto.

## Résolution
Utilisation de la méthode Object.assign pour créer la classe en fonction de l'objet validé