### PR TITLE
Accounts: Bug fixes

### DIFF
--- a/src/accounts/accounts.module.ts
+++ b/src/accounts/accounts.module.ts
@@ -22,10 +22,13 @@ import { StudentsController } from './students.controller';
     ]),
   ],
   controllers: [
-    AccountsController,
     StudentsController,
     CompaniesController,
     ManagedController,
+
+    //! Note: keep the accounts controller at the end of the controllers array.
+    //? To prevent /accounts/students to ping to /accounts/:id (register the /accounts/<type> routes first)
+    AccountsController,
   ],
   providers: [AccountsService],
   exports: [AccountsService],

--- a/src/accounts/dto/administrators/create-administrator.dto.ts
+++ b/src/accounts/dto/administrators/create-administrator.dto.ts
@@ -1,11 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsDefined, MaxLength } from 'class-validator';
 
 export class CreateAdministratorDto {
   @IsDefined()
   @MaxLength(200)
+  @ApiProperty({
+    type: 'string',
+    maxLength: 200,
+  })
   first_name: string;
 
   @IsDefined()
   @MaxLength(200)
+  @ApiProperty({
+    type: 'string',
+    maxLength: 200,
+  })
   last_name: string;
 }

--- a/src/accounts/dto/companies/create-company.dto.ts
+++ b/src/accounts/dto/companies/create-company.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDate, IsDefined, IsString, IsUrl, MaxLength } from 'class-validator';
+import {
+  IsDateString,
+  IsDefined,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
 
 export class CreateCompanyDto {
   @IsDefined()
@@ -7,9 +14,11 @@ export class CreateCompanyDto {
   @ApiProperty({
     type: 'string',
     required: true,
+    maxLength: 250,
   })
   name: string;
 
+  @IsOptional()
   @IsString()
   @ApiProperty({
     type: 'string',
@@ -19,13 +28,14 @@ export class CreateCompanyDto {
   bio?: string;
 
   @IsDefined()
-  @IsDate()
+  @IsDateString()
   @ApiProperty({
     type: 'string',
     format: 'date',
   })
   creation_date: Date;
 
+  @IsOptional()
   @IsString()
   @IsUrl()
   @ApiProperty({
@@ -35,6 +45,7 @@ export class CreateCompanyDto {
   })
   scrapped_from?: string;
 
+  @IsOptional()
   @IsString()
   @IsUrl()
   @ApiProperty({

--- a/src/accounts/dto/companies/create-company.dto.ts
+++ b/src/accounts/dto/companies/create-company.dto.ts
@@ -1,22 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsDate, IsDefined, IsString, IsUrl, MaxLength } from 'class-validator';
 
 export class CreateCompanyDto {
   @IsDefined()
   @MaxLength(250)
+  @ApiProperty({
+    type: 'string',
+    required: true,
+  })
   name: string;
 
   @IsString()
+  @ApiProperty({
+    type: 'string',
+    format: 'html',
+    required: false,
+  })
   bio?: string;
 
   @IsDefined()
   @IsDate()
+  @ApiProperty({
+    type: 'string',
+    format: 'date',
+  })
   creation_date: Date;
 
   @IsString()
   @IsUrl()
+  @ApiProperty({
+    type: 'string',
+    required: false,
+    format: 'url',
+  })
   scrapped_from?: string;
 
   @IsString()
   @IsUrl()
+  @ApiProperty({
+    type: 'string',
+    format: 'url',
+    required: false,
+  })
   website_url?: string;
 }

--- a/src/accounts/dto/managed/create-managed.dto.ts
+++ b/src/accounts/dto/managed/create-managed.dto.ts
@@ -2,11 +2,13 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
   IsDefined,
   IsNumber,
+  IsOptional,
   IsPositive,
   IsUUID,
   MaxLength,
 } from 'class-validator';
 import { Permissions } from 'src/common/enums/permissions';
+import PermissionManager from 'src/common/utils/permissionManager';
 
 export class CreateManagedDto {
   @IsDefined()
@@ -14,6 +16,7 @@ export class CreateManagedDto {
   @ApiProperty({
     type: 'string',
     required: true,
+    maxLength: 150,
   })
   name: string;
 
@@ -23,15 +26,15 @@ export class CreateManagedDto {
   @ApiProperty({
     type: 'integer',
     minimum: 0,
-    maximum: Object.values(Permissions).reduce(
-      (pre, cur) => (typeof cur === 'number' ? pre + cur : pre),
-      0,
-    ),
+    maximum: new PermissionManager().grant(
+      ...Object.values(Permissions).filter((p) => typeof p === 'number'),
+    ).result,
     description:
       "The managed account's permissions. Note that you must have the permissions you want to give to the managed account.",
   })
   permissions: number;
 
+  @IsOptional()
   @IsUUID()
   @ApiProperty({
     type: 'string',

--- a/src/accounts/dto/students/create-student.dto.ts
+++ b/src/accounts/dto/students/create-student.dto.ts
@@ -1,8 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
   IsArray,
-  IsDate,
+  IsDateString,
   IsDefined,
+  IsOptional,
   IsString,
   MaxLength,
 } from 'class-validator';
@@ -13,6 +14,7 @@ export class CreateStudentDto {
   @ApiProperty({
     type: 'string',
     required: true,
+    maxLength: 200,
   })
   first_name: string;
 
@@ -21,18 +23,20 @@ export class CreateStudentDto {
   @ApiProperty({
     type: 'string',
     required: true,
+    maxLength: 200,
   })
   last_name: string;
 
   @IsDefined()
-  @IsDate()
+  @IsDateString()
   @ApiProperty({
     type: 'string',
     format: 'date',
     required: true,
   })
-  birthdate: Date;
+  birthdate: string;
 
+  @IsOptional()
   @IsString()
   @ApiProperty({
     type: 'string',
@@ -41,11 +45,13 @@ export class CreateStudentDto {
   })
   bio?: string;
 
+  @IsOptional()
   @IsArray()
   @ApiProperty({
     type: 'string',
     format: 'url',
     isArray: true,
+    required: false,
   })
   links?: string[];
 }

--- a/src/accounts/entities/account.entity.ts
+++ b/src/accounts/entities/account.entity.ts
@@ -37,6 +37,7 @@ export class Account {
   @ApiProperty({
     type: 'string',
     format: 'email',
+    maxLength: 200,
   })
   email: string;
 

--- a/src/accounts/entities/admin.entity.ts
+++ b/src/accounts/entities/admin.entity.ts
@@ -17,6 +17,7 @@ export class Administrator extends LinkedToAccount {
   })
   @ApiProperty({
     type: 'string',
+    maxLength: 200,
   })
   first_name: string;
 
@@ -25,6 +26,7 @@ export class Administrator extends LinkedToAccount {
   })
   @ApiProperty({
     type: 'string',
+    maxLength: 200,
   })
   last_name: string;
 }

--- a/src/accounts/entities/company.entity.ts
+++ b/src/accounts/entities/company.entity.ts
@@ -24,6 +24,7 @@ export class Company extends LinkedToAccount {
   })
   @ApiProperty({
     type: 'string',
+    maxLength: 250,
   })
   name: string;
 
@@ -50,9 +51,9 @@ export class Company extends LinkedToAccount {
   @ApiProperty({
     type: 'string',
     format: 'url',
-    nullable: true,
+    required: false,
   })
-  scrapped_from: string;
+  scrapped_from?: string;
 
   @Column('varchar', {
     length: 200,

--- a/src/accounts/entities/managed.entity.ts
+++ b/src/accounts/entities/managed.entity.ts
@@ -37,7 +37,7 @@ export class Managed extends LinkedToAccount {
   })
   @ApiProperty({
     type: () => Account,
-    nullable: true,
+    required: false,
     description:
       'The author of the account. If this value is `null`, then this is a system managed account.',
   })
@@ -50,10 +50,9 @@ export class Managed extends LinkedToAccount {
   @ApiProperty({
     type: 'integer',
     minimum: 0,
-    maximum: Object.values(Permissions).reduce(
-      (pre, cur) => (typeof cur === 'number' ? pre + cur : pre),
-      0,
-    ),
+    maximum: new PermissionManager().grant(
+      ...Object.values(Permissions).filter((p) => typeof p === 'number'),
+    ).result,
   })
   permissions: number;
 

--- a/src/accounts/entities/student.entity.ts
+++ b/src/accounts/entities/student.entity.ts
@@ -27,12 +27,14 @@ export class Student extends LinkedToAccount {
   @Column('varchar', { length: 200 })
   @ApiProperty({
     type: 'string',
+    maxLength: 200,
   })
   first_name: string;
 
   @Column('varchar', { length: 200 })
   @ApiProperty({
     type: 'string',
+    maxLength: 200,
   })
   last_name: string;
 

--- a/src/accounts/managed.controller.ts
+++ b/src/accounts/managed.controller.ts
@@ -38,7 +38,7 @@ import { UpdateManagedDto } from './dto/managed/update-managed.dto';
 import { Account } from './entities/account.entity';
 import { Managed } from './entities/managed.entity';
 
-@Controller('managed')
+@Controller('accounts/managed')
 @ApiBearerAuth()
 @ApiBasicAuth()
 @ApiResponse({


### PR DESCRIPTION
- 404 sur `/accounts/<type>` (pagination vide impossible à récupérer)
- Meilleur typage de l'API
- Fix le routing de l'api managed (`/managed/...` -> `/accounts/managed/...`)
- Fix les paramètres de type `date` qui devait être des objets (impossible dans une API`
  - [cf décorateur `@IsDate()` remplacé par `@IsDateString()`](https://github.com/Fyn-JobBoard/api/pull/61/changes/77ab43836e2d098330358502a4d640d2be12bfc8#diff-e0bb516c056bc7a0662f08093c9db34671e975f9d8260b924d1027c170f52680R31)