### PR TITLE
Better auth getter

### DIFF
--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -26,7 +26,7 @@ import {
   ApiResponse,
   refs,
 } from '@nestjs/swagger';
-import { Auth } from 'src/auth/class/auth.class';
+import type { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsA } from 'src/auth/guards/is-logged/decorators/is-a/is-a.decorator';
 import { IsManagedAnd } from 'src/auth/guards/is-logged/decorators/is-managed-and/is-managed-and.decorator';

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -26,6 +26,7 @@ import {
   ApiResponse,
   refs,
 } from '@nestjs/swagger';
+import { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsA } from 'src/auth/guards/is-logged/decorators/is-a/is-a.decorator';
 import { IsManagedAnd } from 'src/auth/guards/is-logged/decorators/is-managed-and/is-managed-and.decorator';
@@ -118,7 +119,7 @@ export class AccountsController {
     id: string,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
   ) {
     const account = await this.accountsService.find(id);
     if (!account) {
@@ -158,7 +159,7 @@ export class AccountsController {
     info: CreateAccountDto,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
   ) {
     const relatedDtos = {
       admin: CreateAdministratorDto,
@@ -222,7 +223,7 @@ export class AccountsController {
     id: string,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
   ) {
     const account = await this.accountsService.find(id);
     if (!account) {
@@ -274,12 +275,12 @@ export class AccountsController {
     dto: UpdateAccountDto,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
 
     @Param('id')
     id: string,
   ) {
-    let account = auth;
+    let account: Account | null = null;
     if (id) {
       const found = await this.accountsService.find(id);
       if (!found) {
@@ -297,6 +298,7 @@ export class AccountsController {
 
       account = found;
     }
+    account ??= await auth.account();
 
     const update = await this.accountsService.update(
       account,
@@ -326,7 +328,7 @@ export class AccountsController {
     dto: UpdateAccountDto,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
   ) {
     return this.update(dto, auth, auth.id);
   }

--- a/src/accounts/companies.controller.ts
+++ b/src/accounts/companies.controller.ts
@@ -20,7 +20,7 @@ import {
   ApiQuery,
   ApiResponse,
 } from '@nestjs/swagger';
-import { Auth } from 'src/auth/class/auth.class';
+import type { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsA } from 'src/auth/guards/is-logged/decorators/is-a/is-a.decorator';
 import { IsLoggedGuard } from 'src/auth/guards/is-logged/is-logged.guard';

--- a/src/accounts/companies.controller.ts
+++ b/src/accounts/companies.controller.ts
@@ -20,6 +20,7 @@ import {
   ApiQuery,
   ApiResponse,
 } from '@nestjs/swagger';
+import { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsA } from 'src/auth/guards/is-logged/decorators/is-a/is-a.decorator';
 import { IsLoggedGuard } from 'src/auth/guards/is-logged/is-logged.guard';
@@ -27,7 +28,6 @@ import { AccountTypes } from 'src/common/enums/accountTypes';
 import { AccountsService } from './accounts.service';
 import { ListCompaniesResponseDto } from './dto/companies/list-companies.response.dto';
 import { UpdateCompanyDto } from './dto/companies/update-company.dto';
-import { Account } from './entities/account.entity';
 import { Company } from './entities/company.entity';
 
 @Controller('accounts/companies')
@@ -158,7 +158,7 @@ export class CompaniesController {
     dto: UpdateCompanyDto,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
   ) {
     return this.update(auth.id, dto);
   }

--- a/src/accounts/managed.controller.ts
+++ b/src/accounts/managed.controller.ts
@@ -22,6 +22,7 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 import assert from 'node:assert';
+import { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsManagedAnd } from 'src/auth/guards/is-logged/decorators/is-managed-and/is-managed-and.decorator';
 import { IsLoggedGuard } from 'src/auth/guards/is-logged/is-logged.guard';
@@ -35,7 +36,6 @@ import { Raw } from 'typeorm';
 import { AccountsService } from './accounts.service';
 import { ListManagedResponseDto } from './dto/managed/list-managed.response.dto';
 import { UpdateManagedDto } from './dto/managed/update-managed.dto';
-import { Account } from './entities/account.entity';
 import { Managed } from './entities/managed.entity';
 
 @Controller('accounts/managed')
@@ -86,7 +86,7 @@ export class ManagedController {
   })
   public async list(
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
 
     @Query('page', {
       transform: (v?: string) => parseInt(v ?? ''),
@@ -141,7 +141,7 @@ export class ManagedController {
   })
   public async get(
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
 
     @Query('id')
     id: string,
@@ -180,7 +180,7 @@ export class ManagedController {
     dto: UpdateManagedDto,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
 
     @Param('id')
     id: string,
@@ -205,7 +205,9 @@ export class ManagedController {
 
     switch (auth.type) {
       case AccountTypes.Managed: {
-        const model = await this.accountsService.getModelOf(auth);
+        const model = await this.accountsService.getModelOf(
+          await auth.account(),
+        );
         assert(model instanceof Managed);
 
         if (!model.checkPermissions().satisfies(dto.permissions ?? 0)) {

--- a/src/accounts/managed.controller.ts
+++ b/src/accounts/managed.controller.ts
@@ -22,7 +22,7 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 import assert from 'node:assert';
-import { Auth } from 'src/auth/class/auth.class';
+import type { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsManagedAnd } from 'src/auth/guards/is-logged/decorators/is-managed-and/is-managed-and.decorator';
 import { IsLoggedGuard } from 'src/auth/guards/is-logged/is-logged.guard';

--- a/src/accounts/students.controller.ts
+++ b/src/accounts/students.controller.ts
@@ -20,6 +20,7 @@ import {
   ApiQuery,
   ApiResponse,
 } from '@nestjs/swagger';
+import { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsA } from 'src/auth/guards/is-logged/decorators/is-a/is-a.decorator';
 import { IsLoggedGuard } from 'src/auth/guards/is-logged/is-logged.guard';
@@ -27,7 +28,6 @@ import { AccountTypes } from 'src/common/enums/accountTypes';
 import { AccountsService } from './accounts.service';
 import { ListStudentsResponseDto } from './dto/students/list-students.response.dto';
 import { UpdateStudentDto } from './dto/students/update-student.dto';
-import { Account } from './entities/account.entity';
 import { Student } from './entities/student.entity';
 
 @Controller('accounts/students')
@@ -157,7 +157,7 @@ export class StudentsController {
     dto: UpdateStudentDto,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
   ) {
     return this.update(auth.id, dto);
   }

--- a/src/accounts/students.controller.ts
+++ b/src/accounts/students.controller.ts
@@ -20,7 +20,7 @@ import {
   ApiQuery,
   ApiResponse,
 } from '@nestjs/swagger';
-import { Auth } from 'src/auth/class/auth.class';
+import type { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsA } from 'src/auth/guards/is-logged/decorators/is-a/is-a.decorator';
 import { IsLoggedGuard } from 'src/auth/guards/is-logged/is-logged.guard';

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { hash } from 'bcryptjs';
 import { Account } from 'src/accounts/entities/account.entity';
 import { Repository } from 'typeorm';
+import { Auth } from './class/auth.class';
 import { JWTContent } from './types/jwt-content';
 
 @Injectable()
@@ -75,6 +76,32 @@ export class AuthService {
 
     return null;
   }
+  /**
+   * Retreive base auth class
+   */
+  public async authenticate(
+    auth:
+      | {
+          email: string;
+          password: string;
+        }
+      | {
+          jwt: string | JWTContent;
+        },
+  ): Promise<Auth | null> {
+    if ('jwt' in auth) {
+      const { jwt } = auth;
+      const decoded = typeof jwt === 'string' ? await this.decode(jwt) : jwt;
+      return decoded ? new Auth(decoded, this.accounts) : null;
+    } else {
+      const found = await this.accounts.findOneBy({
+        email: auth.email,
+        password: await hash(auth.password, process.env.BCRYPT_SALT ?? 10),
+      });
+
+      return found ? new Auth(found, this.accounts) : null;
+    }
+  }
 
   public async loginIn(
     email: string,
@@ -83,15 +110,14 @@ export class AuthService {
     account: Account;
     jwt: string;
   }> {
-    const found = await this.accounts.findOneBy({
-      email,
-      password: await hash(password, process.env.BCRYPT_SALT ?? 10),
-    });
+    const account = await this.authenticate({ email, password }).then((auth) =>
+      auth?.account(),
+    );
 
-    return found
+    return account
       ? {
-          account: found,
-          jwt: await this.jwtOf(found),
+          account,
+          jwt: await this.jwtOf(account),
         }
       : null;
   }

--- a/src/auth/class/auth.class.ts
+++ b/src/auth/class/auth.class.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Account } from 'src/accounts/entities/account.entity';
+import { Repository } from 'typeorm';
+import { BaseJWTContent, JWTContent } from '../types/jwt-content';
+
+@Injectable()
+export class Auth {
+  private cached_account: Account | null = null;
+  constructor(
+    private auth: JWTContent | Account,
+    @InjectRepository(Account)
+    private accounts: Repository<Account>,
+  ) {}
+
+  get id() {
+    return this.auth.id;
+  }
+  get type() {
+    return this.auth.type;
+  }
+  get jwt_version() {
+    return this.auth instanceof Account
+      ? this.auth.jwt_version
+      : this.auth.version;
+  }
+
+  get jwt(): BaseJWTContent {
+    if (this.auth instanceof Account) {
+      return {
+        id: this.auth.id,
+        type: this.auth.type,
+        version: this.auth.jwt_version ?? undefined,
+      } satisfies BaseJWTContent;
+    } else {
+      return this.auth;
+    }
+  }
+
+  async account(refresh = false): Promise<Account> {
+    if (!refresh) {
+      if (this.cached_account) {
+        return this.cached_account;
+      }
+
+      if (this.auth instanceof Account) {
+        return (this.cached_account = this.auth);
+      }
+    }
+
+    return (this.cached_account = await this.accounts.findOneByOrFail({
+      id: this.auth.id,
+    }));
+  }
+}

--- a/src/auth/class/auth.class.ts
+++ b/src/auth/class/auth.class.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Account } from 'src/accounts/entities/account.entity';
 import { Repository } from 'typeorm';
-import { BaseJWTContent, JWTContent } from '../types/jwt-content';
+import type { BaseJWTContent, JWTContent } from '../types/jwt-content';
 
 @Injectable()
 export class Auth {

--- a/src/auth/decorators/getters/account/account.decorator.ts
+++ b/src/auth/decorators/getters/account/account.decorator.ts
@@ -5,18 +5,18 @@ import { AccountTypes } from 'src/common/enums/accountTypes';
 /**
  * Return the current account if the user is logged in and the account.type match the given one
  */
-export const Account = createParamDecorator(
+export const Authenticated = createParamDecorator(
   (type: undefined | AccountTypes, ctx: ExecutionContext) => {
-    const account = RequestAccountResolverMiddleware.getRequestAccount(
+    const auth = RequestAccountResolverMiddleware.getRequestAuth(
       ctx.switchToHttp().getRequest(),
     );
 
-    if (account && (type === undefined || account.type === type)) {
-      return account;
+    if (auth && (type === undefined || auth.type === type)) {
+      return auth;
     }
 
     return undefined;
   },
 );
 
-export const AuthAccount = Account;
+export const AuthAccount = Authenticated;

--- a/src/auth/guards/is-logged/is-logged.guard.ts
+++ b/src/auth/guards/is-logged/is-logged.guard.ts
@@ -7,7 +7,6 @@ import {
 import { Reflector } from '@nestjs/core';
 import assert from 'assert';
 import { AccountsService } from 'src/accounts/accounts.service';
-import { Account } from 'src/accounts/entities/account.entity';
 import { Managed } from 'src/accounts/entities/managed.entity';
 import { RequestAccountResolverMiddleware } from 'src/auth/middlewares/request-account-resolver/request-account-resolver.middleware';
 import { AccountTypes } from 'src/common/enums/accountTypes';
@@ -39,11 +38,11 @@ export class IsLoggedGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const auth = RequestAccountResolverMiddleware.getRequestAccount(
+    const auth = RequestAccountResolverMiddleware.getRequestAuth(
       context.switchToHttp().getRequest(),
     );
 
-    if (!(auth instanceof Account)) {
+    if (!auth) {
       return false;
     }
     const handler = context.getHandler();
@@ -60,7 +59,9 @@ export class IsLoggedGuard implements CanActivate {
       this.reflector.get(IsManagedAnd, handler);
 
     if (managed_predicates && auth.type === AccountTypes.Managed) {
-      const managed = await this.accountServices.getModelOf(auth);
+      const managed = await this.accountServices.getModelOf(
+        await auth.account(),
+      );
       assert(managed instanceof Managed);
 
       if (

--- a/src/auth/middlewares/request-account-resolver/request-account-resolver.middleware.ts
+++ b/src/auth/middlewares/request-account-resolver/request-account-resolver.middleware.ts
@@ -8,6 +8,7 @@ import {
 import type { NextFunction, Request, Response } from 'express';
 import { Account } from 'src/accounts/entities/account.entity';
 import { AuthService } from 'src/auth/auth.service';
+import { Auth } from 'src/auth/class/auth.class';
 
 @Injectable()
 export class RequestAccountResolverMiddleware implements NestMiddleware {
@@ -19,15 +20,22 @@ export class RequestAccountResolverMiddleware implements NestMiddleware {
    * Note that the middleware must have been use to make this method return the account.
    * @returns `undefined` if the middleware has not been used or the request's user is not logged in.
    */
-  public static getRequestAccount(req: Request): Account | undefined {
+  public static getRequestAuth(req: Request): Auth | undefined {
     if (
       this.REQUEST_KEY_STORE in req &&
-      req[this.REQUEST_KEY_STORE] instanceof Account
+      req[this.REQUEST_KEY_STORE] instanceof Auth
     ) {
-      return req[this.REQUEST_KEY_STORE] as Account;
+      return req[this.REQUEST_KEY_STORE] as Auth;
     }
 
     return undefined;
+  }
+
+  public static async getRequestAccount(
+    req: Request,
+  ): Promise<Account | undefined> {
+    const auth = RequestAccountResolverMiddleware.getRequestAuth(req);
+    return auth?.account();
   }
 
   constructor(
@@ -41,7 +49,7 @@ export class RequestAccountResolverMiddleware implements NestMiddleware {
       return next();
     }
 
-    let account: Account | null = null;
+    let auth: Auth | null = null;
 
     const destructured = authorization.split(/\s+/, 2).map((v) => v.trim());
     if (destructured.length !== 2) {
@@ -52,7 +60,7 @@ export class RequestAccountResolverMiddleware implements NestMiddleware {
 
     switch (type.toLowerCase()) {
       case 'bearer': {
-        account = await this.authService.validate(value);
+        auth = await this.authService.authenticate({ jwt: value });
 
         break;
       }
@@ -65,9 +73,7 @@ export class RequestAccountResolverMiddleware implements NestMiddleware {
         }
 
         const [email, password] = decoded.split(':', 2);
-        account = await this.authService
-          .loginIn(email, password)
-          .then((result) => result?.account ?? null);
+        auth = await this.authService.authenticate({ email, password });
 
         break;
       }
@@ -78,12 +84,12 @@ export class RequestAccountResolverMiddleware implements NestMiddleware {
       }
     }
 
-    if (account) {
+    if (auth) {
       Object.defineProperty(
         req,
         RequestAccountResolverMiddleware.REQUEST_KEY_STORE,
         {
-          value: account,
+          value: auth,
           writable: false,
         },
       );

--- a/src/auth/types/jwt-content.d.ts
+++ b/src/auth/types/jwt-content.d.ts
@@ -1,7 +1,11 @@
 import type { AccountTypes } from 'src/common/enums/accountTypes';
 
-export interface JWTContent {
+export interface BaseJWTContent {
   id: string;
   type: AccountTypes;
+  version?: number;
+}
+
+export interface JWTContent extends BaseJWTContent {
   version: number;
 }

--- a/src/formations/formations.controller.ts
+++ b/src/formations/formations.controller.ts
@@ -23,8 +23,8 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 import { AccountsService } from 'src/accounts/accounts.service';
-import { Account } from 'src/accounts/entities/account.entity';
 import { Student } from 'src/accounts/entities/student.entity';
+import { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsA } from 'src/auth/guards/is-logged/decorators/is-a/is-a.decorator';
 import { IsManagedAnd } from 'src/auth/guards/is-logged/decorators/is-managed-and/is-managed-and.decorator';
@@ -65,7 +65,7 @@ export class FormationsController {
     @Body()
     formationDto: CreateFormationDto,
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
   ) {
     return this.createFor(formationDto, auth.id, auth);
   }
@@ -93,7 +93,7 @@ export class FormationsController {
     @Param('student_id')
     student_id: string,
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
   ) {
     const student = await this.accounts.findModel(student_id, Student);
     if (!student) {
@@ -136,7 +136,7 @@ export class FormationsController {
   })
   async list(
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
 
     @Query('page', {
       transform: (v?: string) => parseInt(v ?? ''),
@@ -258,7 +258,7 @@ export class FormationsController {
     @Body()
     formationDto: UpdateFormationDto,
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
     @Param('formation_id', {
       transform: (v?: string) => parseInt(v ?? ''),
     })

--- a/src/formations/formations.controller.ts
+++ b/src/formations/formations.controller.ts
@@ -24,7 +24,7 @@ import {
 } from '@nestjs/swagger';
 import { AccountsService } from 'src/accounts/accounts.service';
 import { Student } from 'src/accounts/entities/student.entity';
-import { Auth } from 'src/auth/class/auth.class';
+import type { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsA } from 'src/auth/guards/is-logged/decorators/is-a/is-a.decorator';
 import { IsManagedAnd } from 'src/auth/guards/is-logged/decorators/is-managed-and/is-managed-and.decorator';

--- a/src/skills/skills.controller.ts
+++ b/src/skills/skills.controller.ts
@@ -25,8 +25,8 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 import { AccountsService } from 'src/accounts/accounts.service';
-import { Account } from 'src/accounts/entities/account.entity';
 import { Student } from 'src/accounts/entities/student.entity';
+import { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsManagedAnd } from 'src/auth/guards/is-logged/decorators/is-managed-and/is-managed-and.decorator';
 import { IsLoggedGuard } from 'src/auth/guards/is-logged/is-logged.guard';
@@ -158,7 +158,7 @@ export class SkillsController {
     skill: CreateSkillDto,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
 
     @Param('student_id')
     student_id?: string,
@@ -219,7 +219,7 @@ export class SkillsController {
     id: number,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
 
     @Param('student_id')
     student_id?: string,
@@ -275,7 +275,7 @@ export class SkillsController {
     id: number,
 
     @AuthAccount()
-    auth: Account,
+    auth: Auth,
 
     @Param('student_id')
     student_id?: string,

--- a/src/skills/skills.controller.ts
+++ b/src/skills/skills.controller.ts
@@ -26,7 +26,7 @@ import {
 } from '@nestjs/swagger';
 import { AccountsService } from 'src/accounts/accounts.service';
 import { Student } from 'src/accounts/entities/student.entity';
-import { Auth } from 'src/auth/class/auth.class';
+import type { Auth } from 'src/auth/class/auth.class';
 import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';
 import { IsManagedAnd } from 'src/auth/guards/is-logged/decorators/is-managed-and/is-managed-and.decorator';
 import { IsLoggedGuard } from 'src/auth/guards/is-logged/is-logged.guard';


### PR DESCRIPTION
## Avant
Récupération du compte depuis la BDD systématique (même avec JWT)

## Maintenant
Utilisation de la classe `Auth` qui permet uniquement au besoin d'aller chercher le compte dans la BDD.

### Propriétés de la classe Auth
`auth.id` -> id de l'utilisateur
`auth.type` -> type de compte de l'utilisateur
`auth.jwt_version` -> version du jwt. Attention: peut être `null` si l'utilisateur n'a pas de jwt associé
`auth.jwt` -> Renvoie un `BaseJWTContent` (`JWTContent` avec la propriété `version` optionnelle)

### Méthodes de la classe Auth
#### `auth.account(refresh?: boolean) -> Promise<Account>` 
Retourne le modèle `Account` associé à l'utilisateur.
Le paramètre `refresh` permet de ne pas utiliser la valeur mise en cache par la dernière utilisateur de cette méthode.

---
## Exemple de code
```ts
import type { Auth } from 'src/auth/class/auth.class';
import { AuthAccount } from 'src/auth/decorators/getters/account/account.decorator';

class ExempleController {
  route(
    @AuthAccount()
    auth: Auth
  ) {
    // logique ici
  }
}
```