### PR TITLE
Fix: accounts update/creation permissions

### DIFF
--- a/console/permissions/calculate.ts
+++ b/console/permissions/calculate.ts
@@ -1,0 +1,25 @@
+import { select } from 'inquirer-select-pro';
+import { Permissions } from 'src/common/enums/permissions';
+
+export async function calculate_permissions() {
+  const choices = await select({
+    message: 'Permissions :',
+    multiple: true,
+    options: Object.entries(Permissions)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .filter(([_, perm]) => typeof perm === 'number')
+      .map(([name, value]: [string, Permissions]) => ({
+        name,
+        value,
+      })),
+  });
+
+  const permission = choices.reduce((pre, cur) => pre + cur, 0);
+  console.log(
+    `Calculated permission: ${permission} (0b${permission.toString(2)}).`,
+  );
+}
+
+if (process.argv[1] === __filename) {
+  calculate_permissions().catch(console.error);
+}

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -3,6 +3,7 @@ import {
   Body,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   HttpException,
   NotFoundException,
@@ -280,28 +281,17 @@ export class AccountsController {
     @Param('id')
     id: string,
   ) {
-    let account: Account | null = null;
-    if (id) {
-      const found = await this.accountsService.find(id);
-      if (!found) {
-        throw new NotFoundException();
-      }
-
-      if (
-        !(
-          [AccountTypes.Admin, AccountTypes.Managed].includes(auth.type) ||
-          auth.id === found.id
-        )
-      ) {
-        throw new UnauthorizedException();
-      }
-
-      account = found;
+    if (
+      !(
+        [AccountTypes.Admin, AccountTypes.Managed].includes(auth.type) ||
+        auth.id === id
+      )
+    ) {
+      throw new ForbiddenException();
     }
-    account ??= await auth.account();
 
     const update = await this.accountsService.update(
-      account,
+      id,
       Object.assign(new UpdateAccountDto(), dto),
     );
     if (update instanceof HttpException) {

--- a/src/accounts/companies.controller.ts
+++ b/src/accounts/companies.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  ForbiddenException,
   Get,
   HttpException,
   NotFoundException,
@@ -124,7 +125,14 @@ export class CompaniesController {
 
     @Body()
     dto: UpdateCompanyDto,
+
+    @AuthAccount()
+    auth: Auth,
   ) {
+    if (!(auth.type === AccountTypes.Admin || auth.id === id)) {
+      throw new ForbiddenException();
+    }
+
     const updated = await this.accountsService.update(
       id,
       Object.assign(new UpdateCompanyDto(), dto),
@@ -160,6 +168,6 @@ export class CompaniesController {
     @AuthAccount()
     auth: Auth,
   ) {
-    return this.update(auth.id, dto);
+    return this.update(auth.id, dto, auth);
   }
 }

--- a/src/accounts/dto/companies/create-company.dto.ts
+++ b/src/accounts/dto/companies/create-company.dto.ts
@@ -2,11 +2,15 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
   IsDateString,
   IsDefined,
+  IsInt,
   IsOptional,
+  IsPositive,
   IsString,
   IsUrl,
   MaxLength,
 } from 'class-validator';
+import { ActivityDomain } from 'src/activity-domains/entities/activity-domain.entity';
+import { Exists } from 'src/common/validators/exists/exists.decorator';
 
 export class CreateCompanyDto {
   @IsDefined()
@@ -34,6 +38,16 @@ export class CreateCompanyDto {
     format: 'date',
   })
   creation_date: Date;
+
+  @IsDefined()
+  @ApiProperty({
+    type: 'integer',
+    description: 'The id of the activity domain the company is associed to',
+  })
+  @IsPositive()
+  @IsInt()
+  @Exists(() => ActivityDomain)
+  activity_domain_id: number;
 
   @IsOptional()
   @IsString()

--- a/src/accounts/entities/company.entity.ts
+++ b/src/accounts/entities/company.entity.ts
@@ -1,9 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { ActivityDomain } from 'src/activity-domains/entities/activity-domain.entity';
 import { Experience } from 'src/experiences/entities/experience.entity';
 import { Job } from 'src/jobs/entities/job.entity';
 import {
   Column,
   Entity,
+  JoinColumn,
+  ManyToOne,
   OneToMany,
   PrimaryColumn,
   type Relation,
@@ -87,4 +90,16 @@ export class Company extends LinkedToAccount {
     isArray: true,
   })
   referenced_experiences: Relation<Experience>[];
+
+  @JoinColumn({
+    name: 'activity_domain_id',
+  })
+  @ManyToOne(() => ActivityDomain, (activity) => activity.companies, {
+    onDelete: 'RESTRICT',
+    onUpdate: 'CASCADE',
+  })
+  @ApiProperty({
+    type: () => ActivityDomain,
+  })
+  activity_domain: Relation<ActivityDomain>;
 }

--- a/src/accounts/students.controller.ts
+++ b/src/accounts/students.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  ForbiddenException,
   Get,
   HttpException,
   NotFoundException,
@@ -123,7 +124,14 @@ export class StudentsController {
 
     @Body()
     dto: UpdateStudentDto,
+
+    @AuthAccount()
+    auth: Auth,
   ) {
+    if (!(auth.type === AccountTypes.Admin || auth.id === id)) {
+      throw new ForbiddenException();
+    }
+
     const updated = await this.accountsService.update(
       id,
       Object.assign(new UpdateStudentDto(), dto),
@@ -159,6 +167,6 @@ export class StudentsController {
     @AuthAccount()
     auth: Auth,
   ) {
-    return this.update(auth.id, dto);
+    return this.update(auth.id, dto, auth);
   }
 }

--- a/src/activity-domains/entities/activity-domain.entity.ts
+++ b/src/activity-domains/entities/activity-domain.entity.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude } from 'class-transformer';
+import { Company } from 'src/accounts/entities/company.entity';
 import { Job } from 'src/jobs/entities/job.entity';
 import {
   Column,
@@ -44,4 +45,11 @@ export class ActivityDomain {
   })
   @Exclude()
   jobs: Relation<Job>[];
+
+  @OneToMany(() => Company, (company) => company.activity_domain, {
+    onDelete: 'RESTRICT',
+    onUpdate: 'CASCADE',
+  })
+  @Exclude()
+  companies: Relation<Company>[];
 }


### PR DESCRIPTION
## Changements
- Meilleur DTO pour l'entité company (implémentation de la colonne `activity_domain_id`)
- Meilleur checks des différentes permissions lors de l'update des comptes

## Nouvelle commande
`bun console permissions.calculate`

De calculer les permissions des comptes.
Cf commit https://github.com/Fyn-JobBoard/api/commit/4c1cccdf39d014f9cec37706485dea072d9a9d94